### PR TITLE
Add Docker Compose setup to run MedCAT and bio-semantic APIs.

### DIFF
--- a/Backend/.gitignore
+++ b/Backend/.gitignore
@@ -7,7 +7,8 @@
 *.pyc
 __pycache__/
 
-
+# This directory will be created automatically when docker-compose up is run
+/models 
 
 # a text file where i store temporary texts like outputs and code snippets...
 clipboard.txt

--- a/Backend/doc_2025-05-23_11-59-47.dockerignore
+++ b/Backend/doc_2025-05-23_11-59-47.dockerignore
@@ -1,0 +1,7 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+env
+venv
+*.gz

--- a/Backend/docker-compose.yml
+++ b/Backend/docker-compose.yml
@@ -1,0 +1,50 @@
+version: "3.9"
+
+services:
+  medcat-service:
+    image: cogstacksystems/medcat-service:latest
+    container_name: medcat-service
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./models:/cat/models:rw
+      - ./medcat-init.sh:/medcat-init.sh:ro
+    entrypoint: ["/bin/bash", "/medcat-init.sh"]
+    restart: unless-stopped
+    networks:
+      - app-network
+    environment:
+      - APP_MODEL_CDB_PATH=/cat/models/medmen.cdb
+      - APP_MODEL_VOCAB_PATH=/cat/models/vocab.dat
+      - env-file=env/app.env \
+      - env-file=env/medcat.env \
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/api/info"]
+      interval: 30s
+      timeout: 20s
+      retries: 10
+      start_period: 2m # Wait for the MedCATservice to be healthy before starting the fastapi-backend (adjust it based on your internet connection speed to download the medmen.cdb and vocab.dat files)
+
+  fastapi-backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: fastapi-backend
+    ports:
+      - "8000:8000"
+    depends_on:
+      medcat-service:
+        condition: service_healthy
+
+    environment:
+      - MEDCAT_URL=http://medcat-service:5000/api/process
+    volumes:
+      - .:/app
+    working_dir: /app
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge

--- a/Backend/dockerfile
+++ b/Backend/dockerfile
@@ -1,0 +1,15 @@
+# Use official Python base image
+FROM python:3.10-slim
+
+# Set working directory in container
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy your entire backend code into the container
+COPY . .
+
+# Set default command
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/Backend/medcat-init.sh
+++ b/Backend/medcat-init.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+# Ensure curl is installed
+if ! command -v curl &> /dev/null; then
+    echo "curl not found, installing..."
+    apt-get update && apt-get install -y curl
+fi
+MODEL_DIR="/cat/models"
+CDB="$MODEL_DIR/medmen.cdb"
+VOCAB="$MODEL_DIR/vocab.dat"
+META_DIR="$MODEL_DIR/mc_status"
+
+# Download medmen.cdb
+if [ ! -f "$CDB" ]; then
+    echo "Downloading medmen.cdb..."
+    curl -L -o "$CDB.tmp" https://cogstack-medcat-example-models.s3.eu-west-2.amazonaws.com/medcat-example-models/cdb-medmen-v1.dat
+    mv "$CDB.tmp" "$CDB"
+else
+    echo "medmen.cdb already exists -- skipping"
+fi
+
+# Download vocab.dat
+if [ ! -f "$VOCAB" ]; then
+    echo "Downloading vocab.dat..."
+    curl -L -o "$VOCAB.tmp" https://cogstack-medcat-example-models.s3.eu-west-2.amazonaws.com/medcat-example-models/vocab.dat
+    mv "$VOCAB.tmp" "$VOCAB"
+else
+    echo "vocab.dat already exists -- skipping"
+fi
+
+# Download and unzip meta model if needed
+if [ ! -d "$META_DIR" ]; then
+    echo "Downloading and extracting MetaCAT model (mc_status)..."
+    mkdir -p "$META_DIR"
+    curl -L -o "$META_DIR/mc_status.zip" https://cogstack-medcat-example-models.s3.eu-west-2.amazonaws.com/medcat-example-models/mc_status.zip
+    unzip "$META_DIR/mc_status.zip" -d "$META_DIR"
+    rm "$META_DIR/mc_status.zip"
+else
+    echo "Meta model already exists -- skipping"
+fi
+
+# Start MedCAT
+chmod +x ./start-service-prod.sh
+exec ./start-service-prod.sh


### PR DESCRIPTION
Docker-compose is used to run MedCATservices and bio-semantic-parser(fastAPI) in two docker containers simultaneously. These way the fastAPI can send requests to MedCATservices. In addition a shell script is added to download the missing models for MedCATservices automatically.